### PR TITLE
Add wider chat bubble for rich media and implement poster download fu…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,6 +46,11 @@
     transition: all 0.3s ease;
   }
   
+  /* Wider bubble for rich media like trailers */
+  .chat-bubble-wide {
+    @apply max-w-full sm:max-w-2xl md:max-w-3xl lg:max-w-4xl xl:max-w-5xl;
+  }
+  
   .chat-bubble:hover {
     transform: translateY(-2px);
     box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -238,7 +238,7 @@ export default function ChatInterface() {
         const finalMessage: ChatMessage = {
           id: generateMessageId(),
           type: 'bot',
-          content: `Perfect! Enjoy your movie night. Feel free to ask for another recommendation anytime!`,
+          content: `Perfect! Enjoy your movie night ❤.`,
           timestamp: new Date()
         }
         setMessages(prev => [...prev, finalMessage])
@@ -422,7 +422,7 @@ export default function ChatInterface() {
               className={`flex ${message.type === 'user' ? 'justify-end' : 'justify-start'}`}
             >
               <motion.div 
-                className={`chat-bubble ${message.type === 'user' ? 'user-bubble' : 'bot-bubble'} relative overflow-hidden`}
+                className={`chat-bubble ${message.type === 'user' ? 'user-bubble' : 'bot-bubble'} ${message.trailerUrl ? 'chat-bubble-wide' : ''} relative overflow-hidden`}
                 whileHover={{ 
                   scale: 1.02, 
                   y: -3,


### PR DESCRIPTION
This pull request introduces improvements to the user experience for movie recommendations and media sharing. The main changes include replacing the Instagram sharing feature with a poster download option in `MovieCard`, updating the chat bubble styling for rich media, and refining the final bot message in the chat interface.

**Media sharing and download enhancements:**

* Replaced the "Share via Instagram DM" feature in `MovieCard` with a "Download Poster" button, allowing users to download the full-size movie poster or open it in a new tab if direct download fails. The button's styling and icon were updated to reflect this new functionality. [[1]](diffhunk://#diff-5a16feb4a6ac41b8dc21e67c26cceb572ad58df51004a9e86e65527000c63fcaL17-R50) [[2]](diffhunk://#diff-5a16feb4a6ac41b8dc21e67c26cceb572ad58df51004a9e86e65527000c63fcaL135-R135)
* Updated imports in `MovieCard` to remove the unused `Instagram` icon and add the `Download` icon for the new poster download feature.

**Chat interface and styling improvements:**

* Added a new `.chat-bubble-wide` class in `globals.css` to support wider chat bubbles for rich media, such as trailers.
* Modified the chat bubble rendering in `ChatInterface` to use the wider bubble style when a trailer URL is present.

**User experience refinement:**

* Updated the final bot message in `ChatInterface` to a friendlier tone, adding a heart emoji to the message.