### PR TITLE
Refactor ChatInterface and MovieCard components to remove trailer pre…

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -21,8 +21,7 @@ export default function ChatInterface() {
     decade: '',
     language: '',
     rating: '',
-    popularity: '',
-    showTrailer: ''
+  popularity: ''
   })
   const [isLoading, setIsLoading] = useState(false)
   const [chatCompleted, setChatCompleted] = useState(false)
@@ -114,30 +113,7 @@ export default function ChatInterface() {
       updatedPreferences.genres = [...currentGenres, response]
       setUserPreferences(updatedPreferences)
       return    } else {
-      // Handle trailer preference
-      if (currentStepData.field === 'showTrailer') {
-        const showTrailer = response.includes('Yes') ? 'yes' : 'no'
-        updatedPreferences = {
-          ...updatedPreferences,
-          showTrailer: showTrailer
-        } as UserPreferences
-        setUserPreferences(updatedPreferences)
-          
-        const trailerMessage: ChatMessage = {
-          id: generateMessageId(),
-          type: 'bot',
-          content: showTrailer === 'yes' ? 
-            `Perfect! I'll include the trailer with your recommendation!` :
-            `Got it! I'll just show you the movie details!`,
-          timestamp: new Date()
-        }
-        setMessages(prev => [...prev, trailerMessage])
-        
-        setTimeout(() => {
-          getRecommendation(updatedPreferences)
-        }, 800)
-        return
-      }
+      // No trailer preference step anymore
       
       setWaitingForConfirmation(true)
       setPendingResponse(response)
@@ -210,29 +186,7 @@ export default function ChatInterface() {
         }
         setMessages(prev => [...prev, recommendationMessage])
         
-        // Handle trailer functionality
-        if (preferences.showTrailer === 'yes') {
-          const trailerUrl = await getMovieTrailer(movieData.id)
-          
-          if (trailerUrl) {
-            const trailerMessage: ChatMessage = {
-              id: generateMessageId(),
-              type: 'bot',
-              content: `Here's the trailer for ${movieData.title}! Enjoy!`,
-              timestamp: new Date(),
-              trailerUrl: trailerUrl
-            }
-            setMessages(prev => [...prev, trailerMessage])
-          } else {
-            const noTrailerMessage: ChatMessage = {
-              id: generateMessageId(),
-              type: 'bot',
-              content: `Sorry, I couldn't find a trailer for this movie, but I'm sure you'll love it anyway!`,
-              timestamp: new Date()
-            }
-            setMessages(prev => [...prev, noTrailerMessage])
-          }
-        }
+        // Trailer embed removed; trailer will be accessed via button on the movie card
         
         // Final message
         const finalMessage: ChatMessage = {
@@ -264,12 +218,11 @@ export default function ChatInterface() {
     setCurrentStep(0)
     setMessageIdCounter(0)
     setUserPreferences({
-      genres: [],
-      decade: '',
-      language: '',
-      rating: '',
-      popularity: '',
-      showTrailer: ''
+  genres: [],
+  decade: '',
+  language: '',
+  rating: '',
+  popularity: ''
     })
     setChatCompleted(false)
     setRecommendedMovie(null)
@@ -308,9 +261,8 @@ export default function ChatInterface() {
       
       const feedbackMessage: ChatMessage = {
         id: generateMessageId(),
-        type: 'bot',        content: currentStepData.field === 'showTrailer' ? 
-          `Perfect! I'll ${pendingResponse.includes('Yes') ? 'include' : 'skip'} the trailer` :
-          `Perfect! You selected "${pendingResponse}"`,
+        type: 'bot',
+        content: `Perfect! You selected "${pendingResponse}"`,
         timestamp: new Date()
       }
       setMessages(prev => [...prev, feedbackMessage])
@@ -422,7 +374,7 @@ export default function ChatInterface() {
               className={`flex ${message.type === 'user' ? 'justify-end' : 'justify-start'}`}
             >
               <motion.div 
-                className={`chat-bubble ${message.type === 'user' ? 'user-bubble' : 'bot-bubble'} ${message.trailerUrl ? 'chat-bubble-wide' : ''} relative overflow-hidden`}
+                className={`chat-bubble ${message.type === 'user' ? 'user-bubble' : 'bot-bubble'} relative overflow-hidden`}
                 whileHover={{ 
                   scale: 1.02, 
                   y: -3,
@@ -475,24 +427,7 @@ export default function ChatInterface() {
                       {/* Light clamp on long bot messages to avoid huge blocks of text */}
                       <p className={`${message.type === 'bot' && message.content.length > 220 ? 'line-clamp-3' : ''}`}>{message.content}</p>
                     </motion.div>
-                    {message.trailerUrl && (
-                      <motion.div 
-                        className="mt-3 sm:mt-4"
-                        initial={{ opacity: 0, scale: 0.9, y: 20 }}
-                        animate={{ opacity: 1, scale: 1, y: 0 }}
-                        transition={{ delay: 0.8, duration: 0.5, type: "spring" }}
-                      >
-                        <div className="relative w-full aspect-video rounded-lg overflow-hidden shadow-lg border border-gold-100/20">
-                          <iframe 
-                            src={message.trailerUrl}
-                            className="absolute inset-0 w-full h-full"
-                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
-                            allowFullScreen
-                            title="Movie Trailer"
-                          />
-                        </div>
-                      </motion.div>
-                    )}
+                    {/* Trailer embed removed in favor of button on MovieCard */}
                     {message.movie && (
                       <motion.div 
                         className="mt-4 sm:mt-6"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,7 +30,6 @@ export interface UserPreferences {
   language: string;
   rating: string;
   popularity: string;
-  showTrailer: string;
 }
 
 export interface ChatStep {

--- a/src/utils/chatSteps.ts
+++ b/src/utils/chatSteps.ts
@@ -26,8 +26,6 @@ export const getChatSteps = (): ChatStep[] => [
       "2010s (2010-2019)", 
       "2000s (2000-2009)",
       "1990s (1990-1999)",
-      "1980s (1980-1989)",
-      "1970s (1970-1979)",
       "Classic (Before 1970)",
       "Any Time Period"
     ],
@@ -77,14 +75,5 @@ export const getChatSteps = (): ChatStep[] => [
     field: "popularity",
     completed: false
   },
-  {
-    id: "trailer",
-    question: "Would you like to watch the official trailer with your recommendation?",
-    options: [
-      "Yes, show me the trailer!",
-      "No, just the movie details"
-    ],
-    field: "showTrailer",
-    completed: false
-  }
+  
 ]


### PR DESCRIPTION
This pull request refactors how movie trailers are presented in the chat-based recommendation flow. Previously, users could opt to have trailers embedded directly in the chat interface. Now, trailer functionality has been moved to a dedicated button on the `MovieCard` component, simplifying the chat experience and making trailer access more intuitive. Several related fields, steps, and UI elements have been removed or updated to reflect this change.

**Chat interface simplification:**

* Removed the `showTrailer` preference and all logic related to trailer selection and embedding from the chat flow in `ChatInterface.tsx`. Trailers are no longer shown as chat messages, and the corresponding user preference field has been deleted. [[1]](diffhunk://#diff-e96246912b1afa2a62284f3107744cf7271bb0a09b6f465f949a383159194114L24-R24) [[2]](diffhunk://#diff-e96246912b1afa2a62284f3107744cf7271bb0a09b6f465f949a383159194114L117-R116) [[3]](diffhunk://#diff-e96246912b1afa2a62284f3107744cf7271bb0a09b6f465f949a383159194114L213-R189) [[4]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476L33) [[5]](diffhunk://#diff-e96246912b1afa2a62284f3107744cf7271bb0a09b6f465f949a383159194114L271-R225) [[6]](diffhunk://#diff-e96246912b1afa2a62284f3107744cf7271bb0a09b6f465f949a383159194114L311-R265) [[7]](diffhunk://#diff-e96246912b1afa2a62284f3107744cf7271bb0a09b6f465f949a383159194114L478-R430)

* Removed the "Would you like to watch the official trailer?" chat step from the chat steps configuration in `chatSteps.ts`.

**MovieCard enhancements:**

* Added a "Watch Trailer" button to the `MovieCard` component, which fetches and opens the trailer in a new tab if available, or alerts the user if not.

* Improved the "Find on Rivestream" button to copy the search query to the clipboard before opening the Rivestream site, enhancing user convenience.

**Code and UI cleanup:**

* Removed the trailer embed UI from chat bubbles and adjusted chat bubble styling accordingly. [[1]](diffhunk://#diff-e96246912b1afa2a62284f3107744cf7271bb0a09b6f465f949a383159194114L425-R377) [[2]](diffhunk://#diff-e96246912b1afa2a62284f3107744cf7271bb0a09b6f465f949a383159194114L478-R430)

* Minor adjustments to the time period options in the chat steps, removing some decades for brevity.